### PR TITLE
Fix setup.py installation on Windows

### DIFF
--- a/c/parwvt.h
+++ b/c/parwvt.h
@@ -9,6 +9,17 @@
 #ifndef PARWVT_H
 #define PARWVT_H 1
 
+/*
+  A B0 macro is defined in termios.h and can interfere with the variable
+  of the same name in this file. The termios B0 macro is related to
+  baud rate of serial modems. We aren't likely to need this definition
+  and it should be safe to undef in the case that termios is included
+  somewhere in the compilation toolchain before this file.
+*/
+#ifdef B0
+#undef B0
+#endif
+
 /* VARIABLES TO HOLD SPEAKER DEFINITION FROM HOST:                    */
 
 static int outsl;   /* Output waveform selector			      */

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ import numpy
 math_lib = ["m"]
 
 if platform.platform()[:7] == "Windows":
-  print("Windows Found - Removing Linking to Math.lib")
   math_lib = []
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,23 @@
 
 from distutils.core import setup
 from distutils.extension import Extension
+import platform
 from Cython.Distutils import build_ext
 import numpy
+
+
+math_lib = ["m"]
+
+if platform.platform()[:7] == "Windows":
+  print("Windows Found - Removing Linking to Math.lib")
+  math_lib = []
+
 
 ext_modules = [
   Extension(
     name="klsyn.klatt_wrap",
     sources=["klsyn/klatt_wrap.pyx"],
-    libraries = ["m"],
+    libraries = math_lib,
     include_dirs=[numpy.get_include()],
     language="c",
   )


### PR DESCRIPTION
Using setup.py to install on windows links against msvc, which does not externally link math libs - so on windows it trys to find non-existent libs and fails to install. Removing the explicit link to the math lib when running under windows fixes this failed check and lets msvc use the default math libs, resulting in a successful build.